### PR TITLE
Creation of email template for email registration

### DIFF
--- a/cloudformation/service/eu-west-2/cognito.yml
+++ b/cloudformation/service/eu-west-2/cognito.yml
@@ -88,8 +88,7 @@ Resources:
                         <h1>Create account - Fares Data Build Tool</h1>
                         <p>To create an account to access the Fares Data Build Tool click the link below:</p>
                         <a href="${RegistrationLink}?key={####}">Link to registration</a>
-                        <p>The link is valid for 72 hours for the following email address email address here</p>
-                        <p style="display: none">{username}</p>
+                        <p>The link is valid for 72 hours for the following email address {username}</p>
                     </div>
                   </div>
                 </div>

--- a/cloudformation/service/eu-west-2/cognito.yml
+++ b/cloudformation/service/eu-west-2/cognito.yml
@@ -13,6 +13,8 @@ Parameters:
     Type: String
   AuthDomain:
     Type: String
+  RegistrationLink:
+    Type: String
 
 Resources:
   UserPool:
@@ -38,6 +40,62 @@ Resources:
           TemporaryPasswordValidityDays: 3
       AdminCreateUserConfig:
         AllowAdminCreateUserOnly: true
+        InviteMessageTemplate:
+          EmailMessage: !Sub |
+            <!DOCTYPE html>
+            <html lang="en">
+              <head>
+                <title>Fares Data Build Tool</title>
+              </head>
+              <body class="govuk-template-body">
+                <div id="main">
+                  <div>
+                    <header style="font-size: 1rem; line-height: 1.25; height: 60px; border-bottom: 10px solid #1d70b8; font-family: Arial, sans-serif; font-weight: 400; color: #ffffff; background: #0b0c0c;" class="govuk-header">
+                      <div style="font-family: Arial, sans-serif;">
+                        <div style="width: 33.33%; padding-left: 10px; float: left;">
+                          <a style="font-weight: 700; display: inline-block; font-size: 30px; line-height: 2; text-decoration: none; color: #ffffff;"
+                            href="https://www.gov.uk/"
+                            ><span style="display: inline-block; margin-right: 5px; color: #ffffff;"
+                              ><svg style="position: relative; margin-right: 1px;"
+                                role="presentation"
+                                focusable="false"
+                                xmlns="http://www.w3.org/2000/svg"
+                                viewBox="0 0 132 97"
+                                height="30"
+                                width="36"
+                              >
+                                <path
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                  d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"
+                                ></path></svg
+                              ><span style="padding-left: 5px;"
+                                >GOV.UK</span
+                              ></span
+                            ></a
+                          >
+                        </div>
+                        <div style="width: 66.66%; padding-left: 15px;">
+                          <a style="color: #ffffff;display: inline-block; margin-bottom: 10px; font-size: 25px; font-weight: 700; text-decoration: none; line-height: 2.5;"
+                            href="/"
+                            id="title_link"
+                            >Fares Data Build Tool</a
+                          >
+                        </div>
+                      </div>
+                    </header>
+                    <div style="font-family: Arial, sans-serif; padding-left: 30px">
+                        <h1>Create account - Fares Data Build Tool</h1>
+                        <p>To create an account to access the Fares Data Build Tool click the link below:</p>
+                        <a href="${RegistrationLink}?key={####}">Link to registration</a>
+                        <p>The link is valid for 72 hours for the following email address email address here</p>
+                        <p style="display: none">{username}</p>
+                    </div>
+                  </div>
+                </div>
+              </body>
+            </html>
+          EmailSubject: "Register for the Fares Data Build Tool"
 
   UserPoolClient:
     Type: "AWS::Cognito::UserPoolClient"

--- a/template/emailTemplate.html
+++ b/template/emailTemplate.html
@@ -44,8 +44,7 @@
             <h1>Create account - Fares Data Build Tool</h1>
             <p>To create an account to access the Fares Data Build Tool click the link below:</p>
             <a href="https://tfn-test.infinityworks.com/register?key={####}">Link to registration</a>
-            <p>The link is valid for 72 hours for the following email address email address here</p>
-            <p style="display: none">{username}</p>
+            <p>The link is valid for 72 hours for the following email address {username}</p>
         </div>
       </div>
     </div>

--- a/template/emailTemplate.html
+++ b/template/emailTemplate.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Fares Data Build Tool</title>
+  </head>
+  <body class="govuk-template-body">
+    <div id="main">
+      <div>
+        <header style="font-size: 1rem; line-height: 1.25; height: 60px; border-bottom: 10px solid #1d70b8; font-family: Arial, sans-serif; font-weight: 400; color: #ffffff; background: #0b0c0c;" class="govuk-header">
+          <div style="font-family: Arial, sans-serif;">
+            <div style="width: 33.33%; padding-left: 10px; float: left;">
+              <a style="font-weight: 700; display: inline-block; font-size: 30px; line-height: 2; text-decoration: none; color: #ffffff;"
+                href="https://www.gov.uk/"
+                ><span style="display: inline-block; margin-right: 5px; color: #ffffff;"
+                  ><svg style="position: relative; margin-right: 1px;"
+                    role="presentation"
+                    focusable="false"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 132 97"
+                    height="30"
+                    width="36"
+                  >
+                    <path
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                      d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"
+                    ></path></svg
+                  ><span style="padding-left: 5px;"
+                    >GOV.UK</span
+                  ></span
+                ></a
+              >
+            </div>
+            <div style="width: 66.66%; padding-left: 15px;">
+              <a style="color: #ffffff;display: inline-block; margin-bottom: 10px; font-size: 25px; font-weight: 700; text-decoration: none; line-height: 2.5;"
+                href="/"
+                id="title_link"
+                >Fares Data Build Tool</a
+              >
+            </div>
+          </div>
+        </header>
+        <div style="font-family: Arial, sans-serif; padding-left: 30px">
+            <h1>Create account - Fares Data Build Tool</h1>
+            <p>To create an account to access the Fares Data Build Tool click the link below:</p>
+            <a href="https://tfn-test.infinityworks.com/register?key={####}">Link to registration</a>
+            <p>The link is valid for 72 hours for the following email address email address here</p>
+            <p style="display: none">{username}</p>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Email template created for the registration process.

As part of this it has been added to the cloud formation.

To test:

- Login into aws console and select the tfn-test-admin
- As the template is already setup in cloudformation you do not need to do anything
- Go to cognito 
- Manage Users pools
- Select 'fdtb-user-pool-test'
- Select users and groups on the left hand side menu
- Create user and enter your email address - make sure you untick phone number verified
- Create the user 
- Check your email and you should have received an email to the following.

Note: The link will be generated but as we do not have the register page it will not work

<img width="1404" alt="Screenshot 2020-05-20 at 08 55 22" src="https://user-images.githubusercontent.com/1183416/82421476-f9726c00-9a78-11ea-81ce-7b40f87516b3.png">
