### PR TITLE
fix: site errors when dynamodb sessions expire

### DIFF
--- a/cloudformation/service/eu-west-2/cognito.yml
+++ b/cloudformation/service/eu-west-2/cognito.yml
@@ -107,9 +107,11 @@ Resources:
     Properties:
       AccessTokenValidity: 20
       IdTokenValidity: 20
+      RefreshTokenValidity: 1
       TokenValidityUnits:
         IdToken: minutes
         AccessToken: minutes
+        RefreshToken: days
       ClientName: !Sub fdbt-site-client-${Stage}
       UserPoolId: !Ref UserPool
       ExplicitAuthFlows:


### PR DESCRIPTION
Adds 24 hour timeout to refresh token to prevent error on DynamoDB session expiry.